### PR TITLE
Fixed set_alarm() for PCF8563.

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -16,7 +16,7 @@
 #define PCF8563_ADDRESS			 0xA3
 #define PCF8583_ADDRESS			 0xA0
 
-#define PCF8563_ALARM			   0x80
+#define PCF8563_ALARM_REG_OFF  0x80
 #define PCF8563_ALARM_AIE		   0x02
 #define PCF8563_ALARM_AF			0x08 // 0x08 : not 0x04!!!!
 /* optional val for no alarm setting */
@@ -214,7 +214,7 @@ unsigned char DateTime::operator>=(const DateTime &date) const
 	return unixtime() >= date.unixtime();
 }
 
-uint8_t DateTime::dayOfWeek() const {	
+uint8_t DateTime::dayOfWeek() const {
 	uint16_t day = date2days(yOff, m, d);
 	return (day + 6) % 7; // Jan 1, 2000 is a Saturday, i.e. returns 6
 }
@@ -692,16 +692,34 @@ DateTime PCF8563::get_alarm()
 }
 
 //Set a daily alarm
-void PCF8563::set_alarm(const DateTime& dt)
+void PCF8563::set_alarm(const DateTime &dt, struct alarm_flags flags)
 {
+  byte minute    = bin2bcd(dt.minute());
+  byte hour      = bin2bcd(dt.hour());
+  byte day       = bin2bcd(dt.day());
+  byte dayOfWeek = bin2bcd(dt.month());
+
+  if( !flags.minute)
+    minute |= PCF8563_ALARM_REG_OFF;
+
+  if( !flags.hour)
+    hour |= PCF8563_ALARM_REG_OFF;
+
+  if( !flags.day)
+    day |= PCF8563_ALARM_REG_OFF;
+
+  if( !flags.wday)
+    dayOfWeek |= PCF8563_ALARM_REG_OFF;
+
   Wire.beginTransmission(address);
   Wire.write(0x09); // Set the register pointer to (0x09)
-  Wire.write(bin2bcd(dt.minute()));
-  Wire.write(bin2bcd(dt.hour()));
-  Wire.write(bin2bcd(dt.day()));
-  Wire.write(bin2bcd(dt.month())); // Set 00 at day
+  Wire.write(minute);
+  Wire.write(hour);
+  Wire.write(day);
+  Wire.write(dayOfWeek);
   Wire.endTransmission();
 }
+
 void PCF8563::off_alarm()
 {
 	//set status2 AF val to zero to reset alarm

--- a/RTClib.h
+++ b/RTClib.h
@@ -4,6 +4,18 @@
 #ifndef _RTCLIB_H_
 #define _RTCLIB_H_
 
+struct alarm_flags {
+  char minute;
+  char hour;
+  char day;
+  char wday;
+};
+
+#define AE_M 1
+#define AE_H 1
+#define AE_D 1
+#define AE_W 1
+
 // TimeDelta which can represent changes in time with seconds accuracy.
 class TimeDelta {
 public:
@@ -137,7 +149,7 @@ class PCF8563 {
 	void off_alarm(void);
 	void on_alarm(void);
 	DateTime get_alarm();
-	void set_alarm(const DateTime& dt);
+  void set_alarm(const DateTime& dt, struct alarm_flags flags);
 };
 
 // RTC using the internal millis() clock, has to be initialized before use

--- a/examples/pcf8563/alarm.ino
+++ b/examples/pcf8563/alarm.ino
@@ -1,0 +1,56 @@
+#include "RTClib.h"
+#include <Wire.h>
+
+PCF8563 rtc;
+DateTime alarm_l;
+const byte rtc_int = 2;
+
+void setup() {
+  Serial.begin(57600);
+  Serial.println("start");
+  pinMode(rtc_int, INPUT);
+  attachInterrupt(digitalPinToInterrupt(rtc_int), interrupt, FALLING);
+  Wire.begin();
+  rtc.begin();
+
+  if (! rtc.isrunning()) {
+    Serial.println("RTC is NOT running!");
+    //rtc.adjust(DateTime(__DATE__, __TIME__));
+  }
+  else
+  {
+    Serial.println("RTC OK");
+    DateTime now = DateTime(2017, 4, 2, 23, 59, 0);
+    rtc.adjust(now);
+
+    setAlarm(1);
+  }
+}
+
+void loop() {
+  DateTime now = rtc.now();
+  char buf[100];
+  strncpy(buf, "DD.MM.YYYY hh:mm:ss\0", 100);
+  Serial.println(now.format(buf));
+
+  delay(1000);
+}
+
+void interrupt()
+{
+  Serial.println("WakeUp atmega");
+}
+
+void setAlarm(int value)
+{
+  char buf[100];
+  strncpy(buf, "DD.MM.YYYY hh:mm:ss\0", 100);
+
+  DateTime alarm = rtc.now();
+  alarm.setminute( alarm.minute() + value);
+  Serial.print("Setting alarm: ");
+  strncpy(buf, "DD hh:mm MM\0", 100);
+  Serial.println(alarm.format(buf));
+  rtc.set_alarm( alarm, {AE_M, 0,  0, 0});
+  rtc.on_alarm();
+}


### PR DESCRIPTION
 Additionally added example how to use alarm with new implementation.