### PR TITLE
Correcting isrunning for PCF8563

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -148,7 +148,7 @@ DateTime::DateTime (const char* date, const char* time) {
 	// sample input: date = "Dec 26 2009", time = "12:34:56"
 	// or date="26-12-2009"
 	yOff = conv2d(date + 9);
-	// Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec 
+	// Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
 	d = conv2d(date + 4);
 	switch (date[0]) {
 		case 'J': m = date[1] == 'a' ? 1 : m = date[2] == 'n' ? 6 : 7; break;
@@ -408,7 +408,7 @@ DateTime DS1307::now() {
   uint8_t d = bcd2bin(WIRE.read());
   uint8_t m = bcd2bin(WIRE.read());
   uint16_t y = bcd2bin(WIRE.read()) + 2000;
-  
+
   return DateTime (y, m, d, hh, mm, ss);
 }
 
@@ -551,7 +551,7 @@ void PCF8583::adjust(const DateTime& dt)
   Wire.write(2000 >> 8);
   Wire.write(2000 & 0x00ff);
   Wire.endTransmission();
-  
+
   begin(); // re set the control/status register to 0x04
 
 }
@@ -633,7 +633,7 @@ DateTime PCF8563::now()
   Wire.write(0x00);
   Wire.endTransmission();
   Wire.requestFrom(address, 9);
-  
+
   status1 = Wire.read();
   status2 = Wire.read();
   uint8_t second = bcd2bin(Wire.read() & 0x7F);
@@ -660,7 +660,7 @@ void PCF8563::adjust(const DateTime& dt)
   Wire.write(bin2bcd(dt.month()) | 0x80);	// Month (1-12, century bit (bit 7) = 1)
   Wire.write(bin2bcd(dt.year() % 100));	  // Year (00-99)
   Wire.endTransmission();
-  
+
   begin(); // re set the control/status register to 0x04
 }
 uint8_t PCF8563::isrunning(void){
@@ -668,12 +668,22 @@ uint8_t PCF8563::isrunning(void){
   Wire.write(0);
   Wire.endTransmission();
 
-  Wire.requestFrom(address, 3);
-  
+  Wire.requestFrom(address, 2);
+
   status1 = Wire.read();
   status2 = Wire.read();
-	
-  // Get VL bit to ensure that clock integrity is garanteed
+  return !(bitRead(status1,5));
+}
+
+uint8_t PCF8563::isvalid(void) {
+  Wire.beginTransmission(address);
+  Wire.write(0);
+  Wire.endTransmission();
+
+  Wire.requestFrom(address, 3);
+
+  status1 = Wire.read();
+  status2 = Wire.read();
   uint8_t VL_seconds = Wire.read();
   return !(bitRead(VL_seconds,7));
 }

--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -664,15 +664,18 @@ void PCF8563::adjust(const DateTime& dt)
   begin(); // re set the control/status register to 0x04
 }
 uint8_t PCF8563::isrunning(void){
-  WIRE.beginTransmission(address);
-  WIRE.write(0);
-  WIRE.endTransmission();
+  Wire.beginTransmission(address);
+  Wire.write(0);
+  Wire.endTransmission();
 
-  WIRE.requestFrom(address, 2);
+  Wire.requestFrom(address, 3);
   
   status1 = Wire.read();
   status2 = Wire.read();
-  return !(bitRead(status1,5));
+	
+  // Get VL bit to ensure that clock integrity is garanteed
+  uint8_t VL_seconds = Wire.read();
+  return !(bitRead(VL_seconds,7));
 }
 
 //Get the alarm at 0x09 adress

--- a/RTClib.h
+++ b/RTClib.h
@@ -145,7 +145,7 @@ class PCF8563 {
 	uint8_t begin(void);
 	DateTime now();
 	uint8_t isrunning(void);
-  uint8_t isvalid(void);
+	uint8_t isvalid(void);
 	void adjust(const DateTime& dt);
 	void off_alarm(void);
 	void on_alarm(void);

--- a/RTClib.h
+++ b/RTClib.h
@@ -126,7 +126,7 @@ class PCF8583 {
   public:
 	PCF8583();
 	PCF8583(int device_address);
-	uint8_t begin(void);	
+	uint8_t begin(void);
 	DateTime now();
 	uint8_t isrunning(void);
 	void adjust(const DateTime& dt);
@@ -142,9 +142,10 @@ class PCF8563 {
   public:
 	PCF8563();
 	PCF8563(int device_address);
-	uint8_t begin(void);	
+	uint8_t begin(void);
 	DateTime now();
 	uint8_t isrunning(void);
+  uint8_t isvalid(void);
 	void adjust(const DateTime& dt);
 	void off_alarm(void);
 	void on_alarm(void);
@@ -161,7 +162,7 @@ public:
 	void begin(const DateTime& dt) { adjust(dt);ok = 1; }
 	void adjust(const DateTime& dt);
 	DateTime now();
-	uint8_t begin(void);	
+	uint8_t begin(void);
 	uint8_t isrunning(void);
 
 protected:


### PR DESCRIPTION
Check clock integrity status register to ensure clock integrity. (see http://www.nxp.com/docs/en/data-sheet/PCF8563.pdf section 8.4.1)

If I understand what isrunning is doing, it should check this register to know if RTC was already set.