### PR TITLE
Update RTClib.cpp - added compile support for ESP8266

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -6,6 +6,9 @@
 #ifdef __AVR__
  #include <avr/pgmspace.h>
  #define WIRE Wire
+#elif defined(ESP8266) 
+ #include <pgmspace.h> 
+ #define WIRE Wire
 #else
  #define PROGMEM
  #define pgm_read_byte(addr) (*(const unsigned char *)(addr))


### PR DESCRIPTION
Support for **ESP8266** boards.
Tested with Sparkfun's "The Thing" ESP8266 (Normal and Dev Board)