### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,10 +7,10 @@
 #######################################
 
 DateTime	KEYWORD1
-TimeDelta KEYWORD1
-DS1302  KEYWORD1
+TimeDelta	KEYWORD1
+DS1302	KEYWORD1
 DS1307	KEYWORD1
-DS3231  KEYWORD1
+DS3231	KEYWORD1
 RTC_Millis	KEYWORD1
 PCF8583	KEYWORD1
 PCF8563	KEYWORD1
@@ -33,7 +33,7 @@ begin	KEYWORD2
 adjust	KEYWORD2
 isrunning	KEYWORD2
 now	KEYWORD2
-format KEYWORD2
+format	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords