### PR TITLE
fix #5. Added data transfer initiation for DS1302.

### DIFF
--- a/RTClib.h
+++ b/RTClib.h
@@ -86,6 +86,18 @@ protected:
 // RTC based on the DS1302 chip connected via pins
 class DS1302 {
 private:
+	//RAII class for data transferring
+	class TransferHelper {
+		public:
+			TransferHelper(uint8_t ce_pin, uint8_t sck_pin);
+			~TransferHelper();
+		protected:
+			uint8_t ce, sck;
+
+			const unsigned int ce_to_sck_setup = 4;
+			const unsigned int ce_inactive_time = 4;
+	};
+
 	uint8_t read();
 	void write(const uint8_t val);
 public:


### PR DESCRIPTION
According to DS1302 datasheet before data transferring CE pin should be set to 1. After transferring CE pin should be set to 0. Datasheet page 4 (section CE AND CLOCK CONTROL), fig. 5 and 6 (timing diagrams), page 11 (AC ELECTRICAL CHARACTERISTICS table). 
Current code doesn't fit this requirement.

Link to datasheet: https://datasheets.maximintegrated.com/en/ds/DS1302.pdf
