### PR TITLE
fix DateTime::format() two-digit year

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -284,7 +284,7 @@ char* DateTime::format(char* ret) {
             ret[i + 1] = '0' + m % 10;
         }
 
-        if (ret[i] == 'Y' && ret[i + 3] == 'Y') {
+        if (ret[i] == 'Y') {
             if (ret[i + 3] == 'Y') {
                 ret[i] = '2';
                 ret[i + 1] = '0';


### PR DESCRIPTION
Fix for two-digit year in DateTime::format(), that was broken in commit e1fb0a48d4f3c74b5d243a13c833439b0c3dd3b6