### PR TITLE
Clean up warnings

### DIFF
--- a/RTClib.cpp
+++ b/RTClib.cpp
@@ -118,7 +118,7 @@ DateTime::DateTime (uint32_t t) {
     uint8_t leap;
     for (yOff = 0; ;++yOff) {
         leap = yOff % 4 == 0;
-        if (days < 365 + leap)
+        if (days < (uint16_t)365 + leap)
             break;
         days -= 365 + leap;
     }
@@ -230,7 +230,7 @@ void DateTime::SetDate(const char* date) {
     // Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
     d = conv2d(date + 4);
     switch (date[0]) {
-        case 'J': m = date[1] == 'a' ? 1 : m = date[2] == 'n' ? 6 : 7; break;
+        case 'J': m = (date[1] == 'a') ? 1 : (date[2] == 'n') ? 6 : 7; break;
         case 'F': m = 2; break;
         case 'A': m = date[2] == 'r' ? 4 : 8; break;
         case 'M': m = date[2] == 'r' ? 3 : 5; break;
@@ -258,7 +258,7 @@ TimeDelta DateTime::operator- (const DateTime& right) const {
 }
 
 char* DateTime::format(char* ret) {
-    for (int i = 0; i < strlen(ret); i++) {
+    for (int i = 0; i < (int)strlen(ret); i++) {
         if (ret[i] == 'h' && ret[i + 1] == 'h') {
             ret[i] = '0' + hh / 10;
             ret[i + 1] = '0' + hh % 10;
@@ -493,6 +493,7 @@ DateTime DS1307::now() {
 
 uint8_t DS3231::begin() {
     write(DS3231_CONTROL_ADDR, DS3231_INTC);
+    return 1;
 }
 
 uint8_t DS3231::read(const uint8_t addr) {
@@ -593,7 +594,6 @@ DateTime PCF8583::now() {
     uint8_t year = (int)((incoming >> 6) & 0x03); // it will only hold 4 years...
     incoming = Wire.read();
     uint8_t month = bcd2bin(incoming & 0x1f);
-    uint8_t dow = incoming >> 5;
 
     // but that's not all - we need to find out what the base year is
     // so we can add the 2 bits we got above and find the real year
@@ -713,9 +713,9 @@ DateTime PCF8563::now() {
     uint8_t minute = bcd2bin(Wire.read() & 0x7F);
     uint8_t hour = bcd2bin(Wire.read() & 0x3F);
     uint8_t day = bcd2bin(Wire.read() & 0x3F);
-    uint8_t wekday = Wire.read() & 0x07; // year/date counter
-    uint8_t month = Wire.read();
-    uint8_t century = month >> 7;
+//    uint8_t wekday = Wire.read() & 0x07; // year/date counter
+    uint8_t month = (uint8_t)Wire.read();
+//    uint8_t century = month >> 7;
     month = bcd2bin(month & 0x1F);
     uint8_t year = bcd2bin(Wire.read()); // it will only hold 4 years...
     return DateTime(year, month, day, hour, minute, second);


### PR DESCRIPTION
The only substantive ones are:
Line 233 removing the indeterminate definition of 'm' due to the prior construct. Tricky logic btw. :)   
And the only other one was the 'return 1;' on DS3231::begin() which was not present. I think a '1' is fine - but you should judge it.