### PR TITLE
Added arduino-pico (Raspberry Pi Pico) compatibility 

### DIFF
--- a/src/RTClib.cpp
+++ b/src/RTClib.cpp
@@ -652,6 +652,7 @@ void DS1307::putram(const uint8_t* arr, uint8_t len) {
 // DS3231 implementation
 uint8_t DS3231::begin() {
     write(DS3231_CONTROL_ADDR, DS3231_INTC);
+    return 0;
 }
 
 uint8_t DS3231::read(uint8_t addr) {

--- a/src/RTClib.h
+++ b/src/RTClib.h
@@ -17,6 +17,10 @@
 #elif defined ESP8266
   #include <pgmspace.h>
   #define WIRE Wire
+#elif defined ARDUINO_RASPBERRY_PI_PICO
+  #include <pgmspace.h>
+  #define WIRE Wire
+  #define BUFFER_LENGTH WIRE_BUFFER_SIZE
 #else
   #define PROGMEM
   #define pgm_read_byte(addr) (*(const unsigned char*)(addr))


### PR DESCRIPTION
Added arduino-pico compatiblity and fixed non-void function not returning a value to make it compile and work with arduino-pico from https://github.com/earlephilhower/arduino-pico on a RP2040. Tested with a DS1307 and working. 