### PR TITLE
Fix update by Arduino library manager

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=RTCLib
+name=RTCLib by NeiroN
 version=1.6.0
 author=JeeLabs (http://news.jeelabs.org/code/), NeiroN (neiron.nxn@gmail.com)
 maintainer=NeiroN (neiron.nxn@gmail.com)


### PR DESCRIPTION
I think I figured it out! I hope it will fix #22
The name of the library cannot be changed, that's why Arduino library manager ignores the new versions!
It should be `RTCLib by NeiroN` and not `RTCLib`, as indicated by the library's indexer log:
https://downloads.arduino.cc/libraries/logs/github.com/NeiroNx/RTCLib/
```
2021/11/06 15:02:50 Checking out tag: v1.6.0
2021/11/06 15:02:50 Release RTCLib:1.6.0 has wrong library name, should be RTCLib by NeiroN
```
You could've requested a name change, but the name `RTCLib` is already taken by Adafruit, so I suggest to keep it as it was.